### PR TITLE
outflowOBC on GPU, preconditioner, remove async cudaMalloc and cudaFree

### DIFF
--- a/src/include/CUDA/arrayCUDA.cuh
+++ b/src/include/CUDA/arrayCUDA.cuh
@@ -100,21 +100,21 @@ public: // utilities
         auto oldArray = arrayPtr;
         cudaErrChk(cudaMalloc(&arrayPtr, arraySize * sizeof(T)));
         cudaErrChk(cudaMemcpyAsync(arrayPtr, oldArray, numberOfElement * sizeof(T), cudaMemcpyDefault, stream));
-        cudaErrChk(cudaFreeAsync(oldArray, stream));
-
         cudaErrChk(cudaStreamSynchronize(stream));
+        cudaErrChk(cudaFree(oldArray));
+        
         return arraySize;
     }
     //! @brief expand the array, must be bigger than original size
     __host__ commonInt expand(commonInt targetedSize, cudaStream_t s){
         if(targetedSize <= arraySize) return arraySize;
-
         arraySize = roundUpToSizeUnit(targetedSize);
         auto oldArray = arrayPtr;
         cudaErrChk(cudaMalloc(&arrayPtr, arraySize * sizeof(T)));
         cudaErrChk(cudaMemcpyAsync(arrayPtr, oldArray, numberOfElement * sizeof(T), cudaMemcpyDefault, s));
-        cudaErrChk(cudaFreeAsync(oldArray, s));
-
+        cudaErrChk(cudaStreamSynchronize(s));
+        cudaErrChk(cudaFree(oldArray));
+        
         return arraySize;
     }
 
@@ -126,9 +126,8 @@ public: // utilities
         auto oldArray = arrayPtr;
         cudaErrChk(cudaMalloc(&arrayPtr, arraySize * sizeof(T)));
         cudaErrChk(cudaMemcpyAsync(arrayPtr, oldArray, numberOfElement * sizeof(T), cudaMemcpyDefault, stream));
-        cudaErrChk(cudaFreeAsync(oldArray, stream));
-
         cudaErrChk(cudaStreamSynchronize(stream));
+        cudaErrChk(cudaFree(oldArray));
 
     }
 

--- a/src/include/CUDA/cudaTypeDef.cuh
+++ b/src/include/CUDA/cudaTypeDef.cuh
@@ -87,7 +87,7 @@ template <typename T>
 __host__ inline T* copyToDevice(T* objectOnHost, cudaStream_t stream = 0){
     if(objectOnHost == nullptr)throw std::runtime_error("CopyToDevice: can not copy a nullptr to device.");
     T* ptr = nullptr;
-    cudaErrChk(cudaMallocAsync(&ptr, sizeof(T), stream));
+    cudaErrChk(cudaMalloc(&ptr, sizeof(T)));
     cudaErrChk(cudaMemcpyAsync(ptr, objectOnHost, sizeof(T), cudaMemcpyDefault, stream));
 
     cudaErrChk(cudaStreamSynchronize(stream));
@@ -98,7 +98,7 @@ template <typename T>
 __host__ inline T* copyArrayToDevice(T* objectOnHost, int numberOfElement, cudaStream_t stream = 0){
     if(objectOnHost == nullptr)throw std::runtime_error("CopyToDevice: can not copy a nullptr to device.");
     T* ptr = nullptr;
-    cudaErrChk(cudaMallocAsync(&ptr, numberOfElement * sizeof(T), stream));
+    cudaErrChk(cudaMalloc(&ptr, numberOfElement * sizeof(T)));
     cudaErrChk(cudaMemcpyAsync(ptr, objectOnHost, numberOfElement * sizeof(T), cudaMemcpyDefault, stream));
 
     cudaErrChk(cudaStreamSynchronize(stream));

--- a/src/include/CUDA/momentKernel.cuh
+++ b/src/include/CUDA/momentKernel.cuh
@@ -28,7 +28,7 @@ public:
 
 };
 
-__global__ void momentKernelStayed(momentParameter* momentParam,
+__global__ void momentKernelStayed(const uint32_t* appendCount, momentParameter* momentParam,
                                     grid3DCUDA* grid,
                                     cudaTypeArray1<cudaMomentType> moments);
 

--- a/src/include/CUDA/particleArrayCUDA.cuh
+++ b/src/include/CUDA/particleArrayCUDA.cuh
@@ -25,7 +25,7 @@ public:
 
     __host__ virtual particleArrayCUDA* copyToDevice(){
         particleArrayCUDA* ptr = nullptr;
-        cudaErrChk(cudaMallocAsync((void**)&ptr, sizeof(particleArrayCUDA), stream));
+        cudaErrChk(cudaMalloc((void**)&ptr, sizeof(particleArrayCUDA)));
         cudaErrChk(cudaMemcpyAsync(ptr, this, sizeof(particleArrayCUDA), cudaMemcpyDefault, stream));
 
         cudaErrChk(cudaStreamSynchronize(stream));

--- a/src/include/EMfields3D.h
+++ b/src/include/EMfields3D.h
@@ -86,6 +86,8 @@ class EMfields3D                // :public Field
     void PoissonImage(double *image, double *vector);
     /*! Image of Maxwell Solver (for Solver) */
     void MaxwellImage(double *im, double *vector);
+    /*! Image of Maxwell Solver without communication (for Solver preconditioner) */
+    void MaxwellImageLocal(double *im, double *vector);
     /*! Maxwell source term (for SOLVER) */
     void MaxwellSource(double *bkrylov);
     /*! Impose a constant charge inside a spherical zone of the domain */

--- a/src/include/GMRES.h
+++ b/src/include/GMRES.h
@@ -18,15 +18,22 @@
  * limitations under the License.
  */
 
-#ifndef GMRES_new2_H
-#define GMRES_new2_H
-
-#include "ipicfwd.h"
-
-typedef void (EMfields3D::*FIELD_IMAGE) (double *, double *);
-typedef void (*GENERIC_IMAGE) (double *, double *);
-
-void GMRES(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field);
-void ApplyPlaneRotation(double &dx, double &dy, double &cs, double &sn);
-
-#endif
+ #ifndef GMRES_new2_H
+ #define GMRES_new2_H
+ 
+ #include "ipicfwd.h"
+ 
+ typedef void (EMfields3D::*FIELD_IMAGE) (double *, double *);
+ typedef void (*GENERIC_IMAGE) (double *, double *);
+ 
+ void GMRES(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field);
+ 
+ void GMRESasPreconditioner(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field,
+                            double *rPrec, double *imPrec, double *sPrec, double *csPrec, double *snPrec, double *yPrec, double **HPrec, double **VPrec);
+ void GMRESasPreconditionerNoComm(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field);
+ void FGMRES(FIELD_IMAGE FunctionImage, FIELD_IMAGE LocalFunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field);
+ 
+ void ApplyPlaneRotation(double &dx, double &dy, double &cs, double &sn);
+ 
+ #endif
+ 

--- a/src/include/Grid3DCU.h
+++ b/src/include/Grid3DCU.h
@@ -100,6 +100,8 @@ public:
 
   /** calculate laplacian on nodes, given a scalar field defined on nodes */
   void lapN2N(arr3_double lapN, const_arr3_double scFieldN, EMfields3D *EMf)const;
+  /** calculate laplacian on nodes without ghost nodes (for solver preconditioner), given a scalar field defined on nodes */
+  void lapN2NLocal(arr3_double lapN, const_arr3_double scFieldN, EMfields3D *EMf)const;
   /** calculate laplacian on central points, given a scalar field defined on central points for Poisson */
   //void lapC2Cpoisson(arr3_double lapC, arr3_double scFieldC)const;
   void lapC2Cpoisson(arr3_double lapC, arr3_double scFieldC, EMfields3D *EMf)const;

--- a/src/include/iPic3D.h
+++ b/src/include/iPic3D.h
@@ -48,6 +48,7 @@ class OutputWrapperFPP;
 #include "particleExchange.cuh"
 #include "threadPool.hpp"
 
+#include <fstream>
 
 
 namespace iPic3D {
@@ -109,6 +110,7 @@ namespace iPic3D {
     //
     // output methods
     //
+    void writeParticleNum(int cycle);
     void WriteRestart(int cycle);
     void WriteConserved(int cycle);
     void WriteVelocityDistribution(int cycle);
@@ -145,6 +147,7 @@ namespace iPic3D {
     double        *momentum; // an array of doubles, total momentum of all particle species
     double        *Qremoved; // array of double, with species length, removed charges from the depopulation area
     Timing        *my_clock;
+    std::ofstream pclNumCSV;
 
 
     int cudaDeviceOnNode; // the device this rank should use

--- a/src/ipic3d/cudaKernel/momentKernel.cu
+++ b/src/ipic3d/cudaKernel/momentKernel.cu
@@ -41,99 +41,102 @@ using commonType = cudaTypeDouble; // calculation type
  * @param moments array4, [x][y][z][density], 
  *                  here[nxn][nyn][nzn][10], must be 0 before kernel launch
  */
-__global__ void momentKernelStayed(momentParameter* momentParam,
+__global__ void momentKernelStayed(const uint32_t* appendCount, momentParameter* momentParam,
                                 grid3DCUDA* grid,
                                 cudaTypeArray1<cudaMomentType> moments)
 {
 
-    uint pidx = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint tidx = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint gridSize = blockDim.x * gridDim.x;
     auto pclsArray = momentParam->pclsArray;
-    if(pidx >= pclsArray->getNOP())return;
-    if(momentParam->departureArray->getArray()[pidx].dest != 0)return; // return the exiting particles, which are out of current domian
+    const uint totPcl = pclsArray->getNOP() + *appendCount;
 
-    // can be const
-    const commonType& inv_dx = grid->invdx;
-    const commonType& inv_dy = grid->invdy;
-    const commonType& inv_dz = grid->invdz;
-    const int& nxn = grid->nxn; // nxn
-    const int& nyn = grid->nyn;
-    const int& nzn = grid->nzn;
-    const commonType& xstart = grid->xStart; // x start
-    const commonType& ystart = grid->yStart;
-    const commonType& zstart = grid->zStart;
-    
-
-    const SpeciesParticle &pcl = pclsArray->getpcls()[pidx];
-    // compute the quadratic moments of velocity
-    const commonType ui = pcl.get_u();
-    const commonType vi = pcl.get_v();
-    const commonType wi = pcl.get_w();
-    const commonType uui = ui * ui;
-    const commonType uvi = ui * vi;
-    const commonType uwi = ui * wi;
-    const commonType vvi = vi * vi;
-    const commonType vwi = vi * wi;
-    const commonType wwi = wi * wi;
-    commonType velmoments[10];
-    velmoments[0] = 1.; // charge density
-    velmoments[1] = ui; // momentum density
-    velmoments[2] = vi;
-    velmoments[3] = wi;
-    velmoments[4] = uui; // second time momentum
-    velmoments[5] = uvi;
-    velmoments[6] = uwi;
-    velmoments[7] = vvi;
-    velmoments[8] = vwi;
-    velmoments[9] = wwi;
-
-    //
-    // compute the weights to distribute the moments
-    //
-    const int ix = 2 + int(floor((pcl.get_x() - xstart) * inv_dx));
-    const int iy = 2 + int(floor((pcl.get_y() - ystart) * inv_dy));
-    const int iz = 2 + int(floor((pcl.get_z() - zstart) * inv_dz));
-    const commonType xi0 = pcl.get_x() - grid->getXN(ix-1); // calculate here
-    const commonType eta0 = pcl.get_y() - grid->getYN(iy - 1);
-    const commonType zeta0 = pcl.get_z() - grid->getZN(iz - 1);
-    const commonType xi1 = grid->getXN(ix) - pcl.get_x();
-    const commonType eta1 = grid->getYN(iy) - pcl.get_y();
-    const commonType zeta1 = grid->getZN(iz) - pcl.get_z();
-    const commonType qi = pcl.get_q();
-    const commonType invVOLqi = grid->invVOL * qi;
-    const commonType weight0 = invVOLqi * xi0;
-    const commonType weight1 = invVOLqi * xi1;
-    const commonType weight00 = weight0 * eta0;
-    const commonType weight01 = weight0 * eta1;
-    const commonType weight10 = weight1 * eta0;
-    const commonType weight11 = weight1 * eta1;
-    commonType weights[8]; // put the invVOL here
-    weights[0] = weight00 * zeta0 * grid->invVOL; // weight000
-    weights[1] = weight00 * zeta1 * grid->invVOL; // weight001
-    weights[2] = weight01 * zeta0 * grid->invVOL; // weight010
-    weights[3] = weight01 * zeta1 * grid->invVOL; // weight011
-    weights[4] = weight10 * zeta0 * grid->invVOL; // weight100
-    weights[5] = weight10 * zeta1 * grid->invVOL; // weight101
-    weights[6] = weight11 * zeta0 * grid->invVOL; // weight110
-    weights[7] = weight11 * zeta1 * grid->invVOL; // weight111
-
-
-    uint32_t posIndex[8];
-    posIndex[0] = toOneDimIndex(nxn, nyn, nzn, ix, iy, iz);
-    posIndex[1] = toOneDimIndex(nxn, nyn, nzn, ix, iy, iz-1);
-    posIndex[2] = toOneDimIndex(nxn, nyn, nzn, ix, iy-1, iz);
-    posIndex[3] = toOneDimIndex(nxn, nyn, nzn, ix, iy-1, iz-1);
-    posIndex[4] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy, iz);
-    posIndex[5] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy, iz-1);
-    posIndex[6] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy-1, iz);
-    posIndex[7] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy-1, iz-1);
-    uint32_t oneDensity = nxn * nyn * nzn;
-    for (int m = 0; m < 10; m++)    // 10 densities
-    for (int c = 0; c < 8; c++)     // 8 grid nodes
+    for(uint pidx = tidx; pidx < totPcl; pidx += gridSize )
     {
-        atomicAdd(&moments[oneDensity*m + posIndex[c]], velmoments[m] * weights[c]); // device scope atomic, should be system scope if p2p direct access
+        if(momentParam->departureArray->getArray()[pidx].dest != 0)continue; // return the exiting particles, which are out of current domian
+
+        // can be const
+        const commonType& inv_dx = grid->invdx;
+        const commonType& inv_dy = grid->invdy;
+        const commonType& inv_dz = grid->invdz;
+        const int& nxn = grid->nxn; // nxn
+        const int& nyn = grid->nyn;
+        const int& nzn = grid->nzn;
+        const commonType& xstart = grid->xStart; // x start
+        const commonType& ystart = grid->yStart;
+        const commonType& zstart = grid->zStart;
+        
+
+        const SpeciesParticle &pcl = pclsArray->getpcls()[pidx];
+        // compute the quadratic moments of velocity
+        const commonType ui = pcl.get_u();
+        const commonType vi = pcl.get_v();
+        const commonType wi = pcl.get_w();
+        const commonType uui = ui * ui;
+        const commonType uvi = ui * vi;
+        const commonType uwi = ui * wi;
+        const commonType vvi = vi * vi;
+        const commonType vwi = vi * wi;
+        const commonType wwi = wi * wi;
+        commonType velmoments[10];
+        velmoments[0] = 1.; // charge density
+        velmoments[1] = ui; // momentum density
+        velmoments[2] = vi;
+        velmoments[3] = wi;
+        velmoments[4] = uui; // second time momentum
+        velmoments[5] = uvi;
+        velmoments[6] = uwi;
+        velmoments[7] = vvi;
+        velmoments[8] = vwi;
+        velmoments[9] = wwi;
+
+        //
+        // compute the weights to distribute the moments
+        //
+        const int ix = 2 + int(floor((pcl.get_x() - xstart) * inv_dx));
+        const int iy = 2 + int(floor((pcl.get_y() - ystart) * inv_dy));
+        const int iz = 2 + int(floor((pcl.get_z() - zstart) * inv_dz));
+        const commonType xi0 = pcl.get_x() - grid->getXN(ix-1); // calculate here
+        const commonType eta0 = pcl.get_y() - grid->getYN(iy - 1);
+        const commonType zeta0 = pcl.get_z() - grid->getZN(iz - 1);
+        const commonType xi1 = grid->getXN(ix) - pcl.get_x();
+        const commonType eta1 = grid->getYN(iy) - pcl.get_y();
+        const commonType zeta1 = grid->getZN(iz) - pcl.get_z();
+        const commonType qi = pcl.get_q();
+        const commonType invVOLqi = grid->invVOL * qi;
+        const commonType weight0 = invVOLqi * xi0;
+        const commonType weight1 = invVOLqi * xi1;
+        const commonType weight00 = weight0 * eta0;
+        const commonType weight01 = weight0 * eta1;
+        const commonType weight10 = weight1 * eta0;
+        const commonType weight11 = weight1 * eta1;
+        commonType weights[8]; // put the invVOL here
+        weights[0] = weight00 * zeta0 * grid->invVOL; // weight000
+        weights[1] = weight00 * zeta1 * grid->invVOL; // weight001
+        weights[2] = weight01 * zeta0 * grid->invVOL; // weight010
+        weights[3] = weight01 * zeta1 * grid->invVOL; // weight011
+        weights[4] = weight10 * zeta0 * grid->invVOL; // weight100
+        weights[5] = weight10 * zeta1 * grid->invVOL; // weight101
+        weights[6] = weight11 * zeta0 * grid->invVOL; // weight110
+        weights[7] = weight11 * zeta1 * grid->invVOL; // weight111
+
+
+        uint32_t posIndex[8];
+        posIndex[0] = toOneDimIndex(nxn, nyn, nzn, ix, iy, iz);
+        posIndex[1] = toOneDimIndex(nxn, nyn, nzn, ix, iy, iz-1);
+        posIndex[2] = toOneDimIndex(nxn, nyn, nzn, ix, iy-1, iz);
+        posIndex[3] = toOneDimIndex(nxn, nyn, nzn, ix, iy-1, iz-1);
+        posIndex[4] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy, iz);
+        posIndex[5] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy, iz-1);
+        posIndex[6] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy-1, iz);
+        posIndex[7] = toOneDimIndex(nxn, nyn, nzn, ix-1, iy-1, iz-1);
+        uint32_t oneDensity = nxn * nyn * nzn;
+        for (int m = 0; m < 10; m++)    // 10 densities
+        for (int c = 0; c < 8; c++)     // 8 grid nodes
+        {
+            atomicAdd(&moments[oneDensity*m + posIndex[c]], velmoments[m] * weights[c]); // device scope atomic, should be system scope if p2p direct access
+        }
     }
-
-
 }
 
 

--- a/src/ipic3d/grids/Grid3DCU.cpp
+++ b/src/ipic3d/grids/Grid3DCU.cpp
@@ -371,6 +371,29 @@ void Grid3DCU::lapN2N(arr3_double lapN, const_arr3_double scFieldN,EMfields3D *E
   divC2N(lapN, gradXC, gradYC, gradZC);
 }
 
+
+/** calculate laplacian on nodes without communication (for solver preconditioner), given a scalar field defined on nodes */
+void Grid3DCU::lapN2NLocal(arr3_double lapN, const_arr3_double scFieldN,EMfields3D *EMf)const
+{
+  //const VirtualTopology3D *vct = &get_vct();
+  // calculate laplacian as divercence of gradient
+  // allocate 3 gradients: defined on central points
+  static array3_double gradXC(nxc, nyc, nzc);
+  static array3_double gradYC(nxc, nyc, nzc);
+  static array3_double gradZC(nxc, nyc, nzc);
+  eqValue(0.0, gradXC, nxc, nyc, nzc);
+  eqValue(0.0, gradYC, nxc, nyc, nzc);
+  eqValue(0.0, gradZC, nxc, nyc, nzc);
+  
+  gradN2C(gradXC, gradYC, gradZC, scFieldN);
+  // communicate with BC
+  //communicateCenterBC(nxc, nyc, nzc, gradXC, 1, 1, 1, 1, 1, 1, vct, EMf);
+  //communicateCenterBC(nxc, nyc, nzc, gradYC, 1, 1, 1, 1, 1, 1, vct, EMf);
+  //communicateCenterBC(nxc, nyc, nzc, gradZC, 1, 1, 1, 1, 1, 1, vct, EMf);
+  divC2N(lapN, gradXC, gradYC, gradZC);
+}
+
+
 /** calculate laplacian on central points, given a scalar field defined on central points */
 void Grid3DCU::lapC2C(arr3_double lapC, const_arr3_double scFieldC)const
 {

--- a/src/ipic3d/iPIC3D.cpp
+++ b/src/ipic3d/iPIC3D.cpp
@@ -48,6 +48,8 @@ int main(int argc, char **argv) {
 
     timeTasks.resetCycle();
 
+    KCode.writeParticleNum(i);
+
     DA.startAnalysis(i);
     KCode.CalculateField(i); // E field
     DA.waitForAnalysis();

--- a/src/ipic3d/particles/Particles3D.cpp
+++ b/src/ipic3d/particles/Particles3D.cpp
@@ -1791,7 +1791,7 @@ void Particles3D::repopulate_particles()
     }
     if (repopulateXrght)
     {      
-      cout << "*** Repopulate Xright species " << ns << " ***" << endl;
+      //cout << "*** Repopulate Xright species " << ns << " ***" << endl;
       for (int i=upXstart; i<=xend; i++)
       for (int j=ybeg; j<=yend; j++)
       for (int k=zbeg; k<=zend; k++)
@@ -2019,7 +2019,7 @@ void Particles3D::repopulate_particles_onlyInjection()
     }
     if (repopulateXrght)
     {      
-      cout << "*** Repopulate Xright species " << ns << " ***" << endl;
+      //cout << "*** Repopulate Xright species " << ns << " ***" << endl;
       for (int i=upXstart; i<=xend; i++)
       for (int j=ybeg; j<=yend; j++)
       for (int k=zbeg; k<=zend; k++)

--- a/src/ipic3d/solvers/GMRES.cpp
+++ b/src/ipic3d/solvers/GMRES.cpp
@@ -30,6 +30,620 @@
 #include "EMfields3D.h"
 #include "VCtopology3D.h"
 
+#include <cstring>
+
+// Flexible-GMRES --> allows to a have a flexible preeconditioner
+void FGMRES(FIELD_IMAGE FunctionImage, FIELD_IMAGE LocalFunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field)
+{
+  if (m > xkrylovlen) {
+    // m need not be the same for all processes,
+    // we cannot restrict this test to the main process,
+    // (although we could probably restrict it to the
+    // process with the highest cartesian rank).
+    eprintf("In GMRES the dimension of Krylov space(m) "
+      "can't be > (length of krylov vector)/(# processors)\n");
+  }
+  //std::cout<< "FGMRES init" <<std::endl;
+  bool GMRESVERBOSE = false;
+  double initial_error, rho_tol;
+  double *r = new double[xkrylovlen];
+  double *im = new double[xkrylovlen];
+
+  double *s = new double[m + 1];
+  double *cs = new double[m + 1];
+  double *sn = new double[m + 1];
+  double *y = new double[m + 3];
+  eqValue(0.0, s, m + 1);
+  eqValue(0.0, cs, m + 1);
+  eqValue(0.0, sn, m + 1);
+  eqValue(0.0, y, m + 3);
+
+
+  // preconditioner parameters and arrays
+  const double tolPrec= tol > 0.001 ? 0.1 : tol*10;
+  const int mPrec = 30;
+  double *rPrec = new double[xkrylovlen];
+  double *imPrec = new double[xkrylovlen];
+
+  double *sPrec = new double[mPrec + 1];
+  double *csPrec = new double[mPrec + 1];
+  double *snPrec = new double[mPrec + 1];
+  double *yPrec = new double[mPrec + 3];
+
+  double **HPrec = newArr2(double, mPrec + 1, mPrec);
+  double **VPrec = newArr2(double, mPrec + 1, xkrylovlen);
+
+
+  // allocate H for storing the results from decomposition
+  double **H = newArr2(double, m + 1, m);
+  for (int ii = 0; ii < m + 1; ii++)
+    for (int jj = 0; jj < m; jj++)
+      H[ii][jj] = 0;
+  // allocate V
+  double **V = newArr2(double, m+1, xkrylovlen);
+  for (int ii = 0; ii < m+1; ii++)
+    for (int jj = 0; jj < xkrylovlen; jj++)
+      V[ii][jj] = 0;
+
+  // allocate Z
+  double **Z = newArr2(double, m, xkrylovlen);
+  for (int ii = 0; ii < m; ii++)
+    for (int jj = 0; jj < xkrylovlen; jj++)
+      Z[ii][jj] = 0;
+
+
+
+  if (GMRESVERBOSE && is_output_thread()) {
+    printf( "------------------------------------\n"
+            "-             FGMRES                -\n"
+            "------------------------------------\n\n");
+  }
+
+  MPI_Comm fieldcomm = (field->get_vct()).getFieldComm();
+  
+  double normb = normP(b, xkrylovlen,&fieldcomm);
+  if (normb == 0.0)
+    normb = 1.0;
+  int itr=0;
+  for (itr = 0; itr < max_iter; itr++)
+  {
+    //std::cout<< "FGMRES for loop iter: "<< itr <<std::endl;
+    // r = b - A*x
+    (field->*FunctionImage) (im, xkrylov);
+    sub(r, b, im, xkrylovlen);
+    initial_error = normP(r, xkrylovlen,&fieldcomm);
+
+    if (itr == 0) {
+      if (is_output_thread())
+        printf("Initial residual: %g norm b vector (source) = %g\n",
+          initial_error, normb);
+        //cout << "Initial residual: " << initial_error << " norm b vector (source) = " << normb << endl;
+      rho_tol = initial_error * tol;
+
+      if ((initial_error / normb) <= tol) {
+        if (is_output_thread())
+          printf("GMRES converged without iterations: initial error < tolerance\n");
+          //cout << "GMRES converged without iterations: initial error < tolerance" << endl;
+        break;
+      }
+    }
+
+    scale(V[0], r, (1.0 / initial_error), xkrylovlen);
+    eqValue(0.0, s, m + 1);
+    s[0] = initial_error;
+    int k = 0;
+    //std::cout<< "FGMRES for loop iter: "<< itr <<std::endl;
+    while (rho_tol < initial_error && k < m) {
+
+      // Z(:,k) = A^-1 V(:,k)
+      //GMRESasPreconditionerNoComm(&Field::MaxwellImageLocal, Z[k], xkrylovlen, V[k], 50, 200, tol/1000, field);
+      GMRESasPreconditioner(&Field::MaxwellImage, Z[k], xkrylovlen, V[k], mPrec, max_iter, tolPrec, field, rPrec,imPrec,sPrec,csPrec,snPrec,yPrec,HPrec,VPrec);
+      //memcpy(Z[k],V[k], sizeof(double)*xkrylovlen); 
+      // w= A*Z(:,k)
+      double *w = V[k+1];
+      (field->*FunctionImage) (w, Z[k]);
+      
+      for (int j = 0; j <= k; j++)
+      {
+        y[j] = dot(w, V[j], xkrylovlen);
+      }
+      y[k+1] = norm2(w,xkrylovlen);
+      {
+        
+        MPI_Allreduce(MPI_IN_PLACE, y, (k+2),
+          MPI_DOUBLE, MPI_SUM, fieldcomm);
+      }
+      
+      for (int j = 0; j <= k; j++) {
+        H[j][k] = y[j];
+        addscale(-H[j][k], V[k+1], V[j], xkrylovlen);
+      }
+      // Is there a numerically stable way to
+      // eliminate this second all-reduce all?
+      H[k+1][k] = normP(V[k+1], xkrylovlen,&fieldcomm);
+      //std::cout<< "FGMRES  H[k+1][k]: "<< H[k+1][k] << "k: "<< k <<std::endl;
+      //
+      // check that vectors are orthogonal
+      //
+      //for (register int j = 0; j <= k; j++) {
+      //  dprint(dotP(w, V[j], xkrylovlen));
+      //}
+
+      double av = sqrt(y[k+1]);
+      // why are we testing floating point numbers
+      // for equality?  Is this supposed to say
+      //if (av < delta * fabs(H[k + 1][k]))
+      const double delta=0.001;
+      if (av + delta * H[k + 1][k] == av)
+      {
+        for (int j = 0; j <= k; j++) {
+          const double htmp = dotP(w, V[j], xkrylovlen,&fieldcomm);
+          H[j][k] = H[j][k] + htmp;
+          addscale(-htmp, w, V[j], xkrylovlen);
+        }
+        H[k + 1][k] = normP(w, xkrylovlen,&fieldcomm);
+      }
+      // normalize the new vector
+      scale(w, (1.0 / H[k + 1][k]), xkrylovlen);
+
+      if (0 < k) {
+
+        for (int j = 0; j < k; j++)
+          ApplyPlaneRotation(H[j + 1][k], H[j][k], cs[j], sn[j]);
+
+        getColumn(y, H, k, m + 1);
+      }
+
+      const double mu = sqrt(H[k][k] * H[k][k] + H[k + 1][k] * H[k + 1][k]);
+      cs[k] = H[k][k] / mu;
+      sn[k] = -H[k + 1][k] / mu;
+      H[k][k] = cs[k] * H[k][k] - sn[k] * H[k + 1][k];
+      H[k + 1][k] = 0.0;
+
+      ApplyPlaneRotation(s[k + 1], s[k], cs[k], sn[k]);
+      initial_error = fabs(s[k]);
+      k++;
+    } 
+    k--;
+    y[k] = s[k] / H[k][k];
+
+    for (int i = k - 1; i >= 0; i--) {
+      double tmp = 0.0;
+      for (int l = i + 1; l <= k; l++)
+        tmp += H[i][l] * y[l];
+      y[i] = (s[i] - tmp) / H[i][i];
+
+    }
+
+
+    for (int j = 0; j < k; j++)
+    {
+      const double yj = y[j];
+      //double* Vj = V[j];
+      double* Zj = Z[j];
+      for (int i = 0; i < xkrylovlen; i++)
+        xkrylov[i] += yj * Zj[i];
+    }
+    // check the actual error on the xkrylov vector --> necessary since the flexi preconditioner breaks the krylov subspace
+    (field->*FunctionImage) (im, xkrylov);
+    sub(r, b, im, xkrylovlen);
+    double final_error = normP(r, xkrylovlen,&fieldcomm);
+    //std::cout<< "Final error X: "<< final_error << std::endl;
+
+    //if (initial_error <= rho_tol) {
+    if (final_error <= rho_tol) {
+      if (is_output_thread())
+      {
+        printf("FGMRES converged at restart # %d; iteration #%d with error: %g\n",
+          itr, k,  initial_error / rho_tol * tol);
+        //cout << "GMRES converged at restart # " << itr << "; iteration #" << k << " with error: " << initial_error / rho_tol * tol << endl;
+      }
+      break;
+    }
+    if (is_output_thread() && GMRESVERBOSE)
+    {
+      printf("Restart: %d error: %g\n", itr,  initial_error / rho_tol * tol);
+      //cout << "Restart: " << itr << " error: " << initial_error / rho_tol * tol << endl;
+    }
+
+  }
+  if(itr==max_iter && is_output_thread())
+  {
+    printf("FGMRES not converged !! Final error: %g\n",
+      initial_error / rho_tol * tol);
+    //cout << "GMRES not converged !! Final error: " << initial_error / rho_tol * tol << endl;
+  }
+
+  delete[]r;
+  delete[]im;
+  delete[]s;
+  delete[]cs;
+  delete[]sn;
+  delete[]y;
+  delArr2(H, m + 1);
+  delArr2(V, m + 1);
+  delArr2(Z, m);
+
+  delete[]rPrec;
+  delete[]imPrec;
+  delete[]sPrec;
+  delete[]csPrec;
+  delete[]snPrec;
+  delete[]yPrec;
+  delArr2(HPrec, mPrec + 1);
+  delArr2(VPrec, mPrec + 1);
+  return;
+}
+
+
+
+void GMRESasPreconditioner(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field,
+double *r, double *im, double *s, double *cs, double *sn, double *y, double **H, double **V)
+{
+if (m > xkrylovlen) {
+  // m need not be the same for all processes,
+  // we cannot restrict this test to the main process,
+  // (although we could probably restrict it to the
+  // process with the highest cartesian rank).
+  eprintf("In GMRES the dimension of Krylov space(m) "
+  "can't be > (length of krylov vector)/(# processors)\n");
+}
+bool GMRESVERBOSE = false;
+double initial_error, rho_tol;
+
+eqValue(0.0, s, m + 1);
+eqValue(0.0, cs, m + 1);
+eqValue(0.0, sn, m + 1);
+eqValue(0.0, y, m + 3);
+
+for (int ii = 0; ii < m + 1; ii++)
+for (int jj = 0; jj < m; jj++)
+H[ii][jj] = 0;
+for (int ii = 0; ii < m+1; ii++)
+for (int jj = 0; jj < xkrylovlen; jj++)
+V[ii][jj] = 0;
+
+
+MPI_Comm fieldcomm = (field->get_vct()).getFieldComm();
+
+double normb = normP(b, xkrylovlen,&fieldcomm);
+if (normb == 0.0)
+  normb = 1.0;
+
+int itr=0;
+for (itr = 0; itr < max_iter; itr++)
+{
+  // r = b - A*x
+  (field->*FunctionImage) (im, xkrylov);
+  sub(r, b, im, xkrylovlen);
+  initial_error = normP(r, xkrylovlen,&fieldcomm);
+
+  if (itr == 0) {
+    /* 
+    if (is_output_thread())
+    printf("Initial residual prec: %g norm b vector (source) = %g\n",initial_error, normb);
+    //cout << "Initial residual: " << initial_error << " norm b vector (source) = " << normb << endl;
+    */
+    rho_tol = initial_error * tol;
+
+    if ((initial_error / normb) <= tol) {
+      //if (is_output_thread())
+      //  printf("GMRES preconditioner converged without iterations: initial error < tolerance\n");
+      //cout << "GMRES converged without iterations: initial error < tolerance" << endl;
+      break;
+    }
+  }
+
+  scale(V[0], r, (1.0 / initial_error), xkrylovlen);
+  eqValue(0.0, s, m + 1);
+  s[0] = initial_error;
+  int k = 0;
+  while (rho_tol < initial_error && k < m) {
+
+    // w= A*V(:,k)
+    double *w = V[k+1];
+    (field->*FunctionImage) (w, V[k]);
+    // old code (many MPI_Allreduce calls)
+    //
+    //const double av = normP(w, xkrylovlen);
+    //for (register int j = 0; j <= k; j++) {
+    //  H[j][k] = dotP(w, V[j], xkrylovlen);
+    //  addscale(-H[j][k], w, V[j], xkrylovlen);
+    //}
+
+    // new code to make a single MPI_Allreduce call
+    for (int j = 0; j <= k; j++){
+      y[j] = dot(w, V[j], xkrylovlen);
+    }
+    y[k+1] = norm2(w,xkrylovlen);
+
+    MPI_Allreduce(MPI_IN_PLACE, y, (k+2), MPI_DOUBLE, MPI_SUM, fieldcomm);
+  
+    for (int j = 0; j <= k; j++) {
+      H[j][k] = y[j];
+      addscale(-H[j][k], V[k+1], V[j], xkrylovlen);
+    }
+    // Is there a numerically stable way to
+    // eliminate this second all-reduce all?
+    H[k+1][k] = normP(V[k+1], xkrylovlen,&fieldcomm);
+    //
+    // check that vectors are orthogonal
+    //
+    //for (register int j = 0; j <= k; j++) {
+    //  dprint(dotP(w, V[j], xkrylovlen));
+    //}
+
+    double av = sqrt(y[k+1]);
+    // why are we testing floating point numbers
+    // for equality?  Is this supposed to say
+    //if (av < delta * fabs(H[k + 1][k]))
+    const double delta=0.001;
+    if (av + delta * H[k + 1][k] == av){
+      for (int j = 0; j <= k; j++) {
+        const double htmp = dotP(w, V[j], xkrylovlen,&fieldcomm);
+        H[j][k] = H[j][k] + htmp;
+        addscale(-htmp, w, V[j], xkrylovlen);
+      }
+      H[k + 1][k] = normP(w, xkrylovlen,&fieldcomm);
+    }
+    // normalize the new vector
+    scale(w, (1.0 / H[k + 1][k]), xkrylovlen);
+
+    if (0 < k) {
+      for (int j = 0; j < k; j++)
+        ApplyPlaneRotation(H[j + 1][k], H[j][k], cs[j], sn[j]);
+
+      getColumn(y, H, k, m + 1);
+    }
+
+    const double mu = sqrt(H[k][k] * H[k][k] + H[k + 1][k] * H[k + 1][k]);
+    cs[k] = H[k][k] / mu;
+    sn[k] = -H[k + 1][k] / mu;
+    H[k][k] = cs[k] * H[k][k] - sn[k] * H[k + 1][k];
+    H[k + 1][k] = 0.0;
+
+    ApplyPlaneRotation(s[k + 1], s[k], cs[k], sn[k]);
+    initial_error = fabs(s[k]);
+    k++;
+  }
+
+  k--;
+  y[k] = s[k] / H[k][k];
+
+  for (int i = k - 1; i >= 0; i--) {
+    double tmp = 0.0;
+    for (int l = i + 1; l <= k; l++)
+      tmp += H[i][l] * y[l];
+    y[i] = (s[i] - tmp) / H[i][i];
+  }
+
+
+  for (int j = 0; j < k; j++)
+  {
+    const double yj = y[j];
+    double* Vj = V[j];
+    for (int i = 0; i < xkrylovlen; i++)
+      xkrylov[i] += yj * Vj[i];
+  }
+
+  if(initial_error <= rho_tol)break;
+}
+
+return;
+}
+
+
+
+
+void GMRESasPreconditionerNoComm(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen, const double *b, int m, int max_iter, double tol, EMfields3D * field)
+{
+  //if (is_output_thread())
+  //  std::cout<< "Init GMRESasPreconditionerNoComm " <<std::endl;
+  if (m > xkrylovlen) {
+    // m need not be the same for all processes,
+    // we cannot restrict this test to the main process,
+    // (although we could probably restrict it to the
+    // process with the highest cartesian rank).
+    eprintf("In GMRES the dimension of Krylov space(m) "
+      "can't be > (length of krylov vector)/(# processors)\n");
+  }
+  bool GMRESVERBOSE = false;
+  double initial_error, rho_tol;
+  double *r = new double[xkrylovlen];
+  double *im = new double[xkrylovlen];
+
+  double *s = new double[m + 1];
+  double *cs = new double[m + 1];
+  double *sn = new double[m + 1];
+  double *y = new double[m + 3];
+  eqValue(0.0, s, m + 1);
+  eqValue(0.0, cs, m + 1);
+  eqValue(0.0, sn, m + 1);
+  eqValue(0.0, y, m + 3);
+
+
+  // allocate H for storing the results from decomposition
+  double **H = newArr2(double, m + 1, m);
+  for (int ii = 0; ii < m + 1; ii++)
+    for (int jj = 0; jj < m; jj++)
+      H[ii][jj] = 0;
+  // allocate V
+  double **V = newArr2(double, m+1, xkrylovlen);
+  for (int ii = 0; ii < m+1; ii++)
+    for (int jj = 0; jj < xkrylovlen; jj++)
+      V[ii][jj] = 0;
+
+
+
+  if (GMRESVERBOSE && is_output_thread()) {
+    printf( "------------------------------------\n"
+            "-             GMRES preconditioner No comm              -\n"
+            "------------------------------------\n\n");
+  }
+
+  double normb = sqrt(norm2(b, xkrylovlen));
+  if (normb == 0.0)
+    normb = 1.0;
+
+  int itr=0;
+  for (itr = 0; itr < max_iter; itr++)
+  {
+    // r = b - A*x
+    (field->*FunctionImage) (im, xkrylov);
+    sub(r, b, im, xkrylovlen);
+    initial_error = sqrt(norm2(r, xkrylovlen));
+
+    if (itr == 0) {
+      if (GMRESVERBOSE && is_output_thread())
+        printf("Initial residual prec No Comm: %g norm b vector (source) = %g\n",
+          initial_error, normb);
+        //cout << "Initial residual: " << initial_error << " norm b vector (source) = " << normb << endl;
+      rho_tol = initial_error * tol;
+
+      if ((initial_error / normb) <= tol) {
+        if (GMRESVERBOSE && is_output_thread())
+          printf("GMRES preconditioner No Comm converged without iterations: initial error < tolerance\n");
+          //cout << "GMRES converged without iterations: initial error < tolerance" << endl;
+        break;
+      }
+    }
+
+    scale(V[0], r, (1.0 / initial_error), xkrylovlen);
+    eqValue(0.0, s, m + 1);
+    s[0] = initial_error;
+    int k = 0;
+    while (rho_tol < initial_error && k < m) {
+
+      // w= A*V(:,k)
+      double *w = V[k+1];
+      (field->*FunctionImage) (w, V[k]);
+      // old code (many MPI_Allreduce calls)
+      //
+      //const double av = normP(w, xkrylovlen);
+      //for (register int j = 0; j <= k; j++) {
+      //  H[j][k] = dotP(w, V[j], xkrylovlen);
+      //  addscale(-H[j][k], w, V[j], xkrylovlen);
+      //}
+
+      // new code to make a single MPI_Allreduce call
+      for (int j = 0; j <= k; j++)
+      {
+        y[j] = dot(w, V[j], xkrylovlen);
+      }
+      y[k+1] = norm2(w,xkrylovlen);
+      {
+        
+        //MPI_Allreduce(MPI_IN_PLACE, y, (k+2),MPI_DOUBLE, MPI_SUM, fieldcomm);
+      }
+      for (int j = 0; j <= k; j++) {
+        H[j][k] = y[j];
+        addscale(-H[j][k], V[k+1], V[j], xkrylovlen);
+      }
+      // Is there a numerically stable way to
+      // eliminate this second all-reduce all?
+      H[k+1][k] = sqrt(norm2(V[k+1], xkrylovlen));
+      //
+      // check that vectors are orthogonal
+      //
+      //for (register int j = 0; j <= k; j++) {
+      //  dprint(dotP(w, V[j], xkrylovlen));
+      //}
+      
+      double av = sqrt(y[k+1]);
+      // why are we testing floating point numbers
+      // for equality?  Is this supposed to say
+      //if (av < delta * fabs(H[k + 1][k]))
+      const double delta=0.001;
+      if (av + delta * H[k + 1][k] == av)
+      {
+        for (int j = 0; j <= k; j++) {
+          const double htmp = dot(w, V[j], xkrylovlen);
+          H[j][k] = H[j][k] + htmp;
+          addscale(-htmp, w, V[j], xkrylovlen);
+        }
+        H[k + 1][k] = sqrt(norm2(w, xkrylovlen));
+      }
+      
+
+      // normalize the new vector
+      scale(w, (1.0 / H[k + 1][k]), xkrylovlen);
+
+      if (0 < k) {
+
+        for (int j = 0; j < k; j++)
+          ApplyPlaneRotation(H[j + 1][k], H[j][k], cs[j], sn[j]);
+
+        getColumn(y, H, k, m + 1);
+      }
+
+      const double mu = sqrt(H[k][k] * H[k][k] + H[k + 1][k] * H[k + 1][k]);
+      cs[k] = H[k][k] / mu;
+      sn[k] = -H[k + 1][k] / mu;
+      H[k][k] = cs[k] * H[k][k] - sn[k] * H[k + 1][k];
+      H[k + 1][k] = 0.0;
+
+      ApplyPlaneRotation(s[k + 1], s[k], cs[k], sn[k]);
+      initial_error = fabs(s[k]);
+      k++;
+    }
+
+    k--;
+    y[k] = s[k] / H[k][k];
+
+    for (int i = k - 1; i >= 0; i--) {
+      double tmp = 0.0;
+      for (int l = i + 1; l <= k; l++)
+        tmp += H[i][l] * y[l];
+      y[i] = (s[i] - tmp) / H[i][i];
+
+    }
+
+
+    for (int j = 0; j < k; j++)
+    {
+      const double yj = y[j];
+      double* Vj = V[j];
+      for (int i = 0; i < xkrylovlen; i++)
+        xkrylov[i] += yj * Vj[i];
+    }
+
+    if (initial_error <= rho_tol) {
+      if (is_output_thread())
+      {
+        printf("GMRES preconditioner converged at restart # %d; iteration #%d with error: %g\n",
+          itr, k,  initial_error / rho_tol * tol);
+        //cout << "GMRES converged at restart # " << itr << "; iteration #" << k << " with error: " << initial_error / rho_tol * tol << endl;
+      }
+      break;
+    }
+    if (is_output_thread() && GMRESVERBOSE)
+    {
+      printf("GMRES preconditioner Restart: %d error: %g\n", itr,  initial_error / rho_tol * tol);
+      //cout << "Restart: " << itr << " error: " << initial_error / rho_tol * tol << endl;
+    }
+
+  }
+  if(itr==max_iter && is_output_thread())
+  {
+    printf("GMRES preconditioner not converged !! Final error: %g\n",
+      initial_error / rho_tol * tol);
+    //cout << "GMRES not converged !! Final error: " << initial_error / rho_tol * tol << endl;
+  }
+
+  delete[]r;
+  delete[]im;
+  delete[]s;
+  delete[]cs;
+  delete[]sn;
+  delete[]y;
+  delArr2(H, m + 1);
+  delArr2(V, m + 1);
+  return;
+}
+ 
+ 
+ 
+ 
 void GMRES(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen,
   const double *b, int m, int max_iter, double tol, Field * field)
 {
@@ -201,7 +815,7 @@ void GMRES(FIELD_IMAGE FunctionImage, double *xkrylov, int xkrylovlen,
       for (int i = 0; i < xkrylovlen; i++)
         xkrylov[i] += yj * Vj[i];
     }
-
+    
     if (initial_error <= rho_tol) {
       if (is_output_thread())
       {


### PR DESCRIPTION
- update outflow OBC on GPU -> particles are exchanged between subdomains
- write to csv number of particle per subdomain
- remove async calls cudaMalloc and cudaFree  --> issues on HIP
- add FGMRES solver with nested global GMRES as precondition (beta version)